### PR TITLE
Make container run as unpriviled user

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ I am asking myself the same question and couldn't find an answer to that - yet.
 This is simply a basic setup for a specific wordpress architecture to reduce the pain for the developers. It's packed into a docker container. So you basically have a package with the basic stuff required for a minimal wordpress setup (including plugins, settings, users etc.). You're welcome. You only need to attach the corresponding volumes in order to customize the instance. Sounds pretty simple? It is, indeed. But don't get me wrong, wordpress still sucks on a very high level and it will suck as long as there are developers supporting (and using) it. Me included, per se. So consider this package a painkiller for the agony that comes with wordpress.
 
 ## Documentation
-A more detailed documentation can be found [here](https://wordpress-breeze.github.io/).
+A more detailed documentation can be found [here](https://dorfjungs.github.io/wordpress-breeze).
 
 ## Development
 This whole package will be published by the dockerhub build automation. To trigger this you can simply push a tag and dockerhub handles the process for you.

--- a/dockerfile
+++ b/dockerfile
@@ -28,15 +28,6 @@ ENV THEME_DIR=/var/www/app/content/themes/breeze
 # Add app
 COPY . /var/www/app
 
-# # Expose volumes
-# VOLUME /var/mnt/src \
-#        /var/mnt/assets \
-#        /var/mnt/templates \
-#        /var/mnt/composer \
-#        /var/mnt/uploads \
-#        /var/mnt/vendor \
-#        /var/mnt/exports
-
 RUN mkdir -p /var/mnt/src \
        /var/mnt/assets \
        /var/mnt/templates \

--- a/dockerfile
+++ b/dockerfile
@@ -28,18 +28,22 @@ ENV THEME_DIR=/var/www/app/content/themes/breeze
 # Add app
 COPY . /var/www/app
 
-# Expose volumes
-VOLUME /var/mnt/src \
+# # Expose volumes
+# VOLUME /var/mnt/src \
+#        /var/mnt/assets \
+#        /var/mnt/templates \
+#        /var/mnt/composer \
+#        /var/mnt/uploads \
+#        /var/mnt/vendor \
+#        /var/mnt/exports
+
+RUN mkdir -p /var/mnt/src \
        /var/mnt/assets \
        /var/mnt/templates \
        /var/mnt/composer \
        /var/mnt/uploads \
        /var/mnt/vendor \
        /var/mnt/exports
-
-# Set correct permissions
-RUN chown -R 1000:1000 /var/mnt/*
-RUN ls -al /var/mnt
 
 # Create symlink
 RUN ln -sf /var/mnt/src $THEME_DIR/src && \
@@ -50,6 +54,7 @@ RUN ln -sf /var/mnt/src $THEME_DIR/src && \
     ln -sf /var/mnt/composer /var/www/app/composer
 
 # Set correct permissions
+RUN chown -R www-data:www-data /var/mnt/
 RUN chown -R www-data:www-data /var/www/
 
 # Copy entrypoint

--- a/dockerfile
+++ b/dockerfile
@@ -9,7 +9,6 @@ RUN apt-get -q update && apt-get -qy install \
 
 # Install wp-cli
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && chmod +x ./wp-cli.phar && mv wp-cli.phar /usr/bin/wp
-RUN echo 'alias wp="wp --allow-root"' >>  ~/.bashrc
 
 # Install improved package installer for composer
 RUN composer global require hirak/prestissimo
@@ -37,6 +36,10 @@ VOLUME /var/mnt/src \
        /var/mnt/uploads \
        /var/mnt/vendor \
        /var/mnt/exports
+
+# Set correct permissions
+RUN chown -R 1000:1000 /var/mnt/*
+RUN ls -al /var/mnt
 
 # Create symlink
 RUN ln -sf /var/mnt/src $THEME_DIR/src && \

--- a/docs/deployment/production.md
+++ b/docs/deployment/production.md
@@ -34,5 +34,5 @@ RUN composer install \
 
 # Simple health check for production
 HEALTHCHECK --interval=30s --timeout=30s --start-period=30s --retries=4 \
-  CMD curl -f http://localhost:80/ || exit 1
+  CMD curl -f http://localhost:8080/ || exit 1
 ```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -23,6 +23,8 @@ app:
     DATABASE_NAME: someDbName
     DATABASE_USER: someDbUser
     DATABASE_PASS: aComplexDatabasePassword
+  ports:
+    - 80:8080
 ```
 
 ## The entrypoint

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -94,7 +94,7 @@ if \
     fi
 else
   echo "Skipping composer install for production!"
-fi´
+fi
 
 # Install patternlab if required
 PATTERN_CONSUMER=/var/mnt/templates/pattern


### PR DESCRIPTION
For security reasons, wordpress-breeze now runs as user 'www-data' (UID 1000).
Since non-root users can't bind to well-known ports, the webserver now binds to port 8080 instead of 80.